### PR TITLE
Use the qualified name of “Result” in “mopo!"

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ macro_rules! mopo {
                     None
                 }
             }
-            pub fn query<U: ::std::any::Any + ?Sized>(self: Box<Self>) -> Result<Box<U>, Box<Self>> {
+            pub fn query<U: ::std::any::Any + ?Sized>(self: Box<Self>) -> ::std::result::Result<Box<U>, Box<Self>> {
                 if let Some(vtable) = self.query_vtable(::std::any::TypeId::of::<U>()) {
                     unsafe {
                         let data = Box::into_raw(self);


### PR DESCRIPTION
Currently, `mopo!` refers to `std::result::Result` by its unqualified name `Result`. In most cases it’s OK, but it causes a problem when a type alias with the same name is already defined at the same level. 

For example, the following code does not compile because `mopo!` thinks `Result` is `std::result::Result<T, E>`, but it’s actually `std::io::Result<T>`:

```rust
use std::io::Result;
trait MyLittleInterface {}
mopo!(MyLittleInterface);
```

Similarly, the following code does not compile either:

```rust
type Result<T> = ::std::result::Result<T, u32>;
trait MyLittleInterface {}
mopo!(MyLittleInterface);
```

This PR fixes `mopo!` to use the fully qualified name of `Result`.