### PR TITLE
Use `local_inner_macros` to resolve inner macro invocations within `$crate`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,7 +354,7 @@ impl<T: Hash + Object> ObjectHash for T {
 /// interfaces!(Foo: ObjectClone);
 /// # fn main() {}
 /// ```
-#[macro_export]
+#[macro_export(local_inner_macros)]
 macro_rules! interfaces {
     (@unbracket $(($($v:tt)*))*) => ($($($v)*)*);
     (@inner $imp:tt $cond:tt $name:ty: $($iface:ty),+ {}) => (


### PR DESCRIPTION
This fixes errors when using `interfaces!` via Rust 2018 style macro imports like `use query_interface::interfaces;`.

Related issue: https://github.com/rust-lang-nursery/lazy-static.rs/pull/107
